### PR TITLE
Reset the onboarding if the disclaimer wasn't accepted

### DIFF
--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -238,6 +238,14 @@ angular.module('canoeApp.services')
         }
         if (!profile) {
           return cb(new Error('NOPROFILE: No profile'))
+        } else if (!profile.disclaimerAccepted) {
+          // Hacky: if the disclaimer wasn't accepted, assume the onboarding didn't complete
+          // so just remove the profile
+          storageService.deleteProfile(
+            () => {
+              root.loadAndBindProfile(cb)
+            }
+          )
         } else {
           $log.debug('Profile read')
           $log.debug('Profile: ' + JSON.stringify(profile))


### PR DESCRIPTION
This is a bit of a hack to make sure people get through the onboarding. If your profile hadn't accepted the disclaimer on the initial profile load, we simply throw out the profile (thus triggering the onboarding again)

Fixes #26 