### PR TITLE
Fix Issue with Receive Address prepending xrb:

### DIFF
--- a/src/js/controllers/tab-receive.js
+++ b/src/js/controllers/tab-receive.js
@@ -81,7 +81,7 @@ angular.module('canoeApp.controllers').controller('tabReceiveController', functi
     } else {
       $scope.account = acc
       $scope.addr = acc.id
-      $scope.addrUrl = acc.id
+      $scope.addrUrl = 'xrb:' + acc.id
     }
   }
 

--- a/src/js/controllers/tab-receive.js
+++ b/src/js/controllers/tab-receive.js
@@ -81,7 +81,7 @@ angular.module('canoeApp.controllers').controller('tabReceiveController', functi
     } else {
       $scope.account = acc
       $scope.addr = acc.id
-      $scope.addrUrl = 'xrb:' + acc.id
+      $scope.addrUrl = acc.id
     }
   }
 

--- a/src/js/controllers/tab-receive.js
+++ b/src/js/controllers/tab-receive.js
@@ -93,6 +93,6 @@ angular.module('canoeApp.controllers').controller('tabReceiveController', functi
 
   $scope.shareAccount = function () {
     if (!$scope.isCordova) return
-    window.plugins.socialsharing.share('xrb:' + $scope.addr, null, null, null)
+    window.plugins.socialsharing.share($scope.addr, null, null, null)
   }
 })

--- a/www/views/tab-receive.html
+++ b/www/views/tab-receive.html
@@ -17,8 +17,8 @@
     </article>
     <article class="address" ng-if="accounts[0]">
       <div class="address-info" ng-if="account">
-        <div copy-to-clipboard="addrUrl">
-          <qrcode ng-if="addr" size="220" data="xrb:{{addr}}" color="#334"></qrcode>
+        <div copy-to-clipboard="addr">
+          <qrcode ng-if="addrUrl" size="220" data="{{addrUrl}}" color="#334"></qrcode>
           <div class="address-label">
             <span class="ellipsis">{{addr}}</span>
             <ion-spinner ng-show="!addr" class="spinner-dark" icon="crescent"></ion-spinner>

--- a/www/views/tab-receive.html
+++ b/www/views/tab-receive.html
@@ -20,7 +20,7 @@
         <div copy-to-clipboard="addrUrl">
           <qrcode ng-if="addr" size="220" data="xrb:{{addr}}" color="#334"></qrcode>
           <div class="address-label">
-            <span class="ellipsis">xrb:{{addr}}</span>
+            <span class="ellipsis">{{addr}}</span>
             <ion-spinner ng-show="!addr" class="spinner-dark" icon="crescent"></ion-spinner>
           </div>
         </div>


### PR DESCRIPTION
Fixes #48 

When copying and displaying the address the xrb: prefix is no longer there.

I made sure to leave the xrb: prefix in the QR code itself as to follow the QR code standard.
https://github.com/clemahieu/raiblocks/wiki/URI-and-QR-Code-Standard

Additionally, I removed the xrb: prefix when sharing an address also